### PR TITLE
Remove redundant string checks

### DIFF
--- a/86BoxManager/dlgAddVM.cs
+++ b/86BoxManager/dlgAddVM.cs
@@ -38,7 +38,7 @@ namespace _86boxManager
 
         private void txtName_TextChanged(object sender, EventArgs e)
         {
-            if (string.IsNullOrEmpty(txtName.Text) || string.IsNullOrWhiteSpace(txtName.Text))
+            if (string.IsNullOrWhiteSpace(txtName.Text))
             {
                 btnAdd.Enabled = false;
             }

--- a/86BoxManager/dlgEditVM.cs
+++ b/86BoxManager/dlgEditVM.cs
@@ -62,7 +62,7 @@ namespace _86boxManager
         private void txtName_TextChanged(object sender, EventArgs e)
         {
             //Check for empty strings etc.
-            if (string.IsNullOrEmpty(txtName.Text) || string.IsNullOrWhiteSpace(txtName.Text))
+            if (string.IsNullOrWhiteSpace(txtName.Text))
             {
                 btnApply.Enabled = false;
             }

--- a/86BoxManager/dlgSettings.cs
+++ b/86BoxManager/dlgSettings.cs
@@ -55,7 +55,7 @@ namespace _86boxManager
 
         private void txt_TextChanged(object sender, EventArgs e)
         {
-            if (string.IsNullOrEmpty(txtCFGdir.Text) || string.IsNullOrWhiteSpace(txtCFGdir.Text) || string.IsNullOrEmpty(txtEXEdir.Text) || string.IsNullOrWhiteSpace(txtEXEdir.Text))
+            if (string.IsNullOrWhiteSpace(txtCFGdir.Text) || string.IsNullOrWhiteSpace(txtEXEdir.Text))
             {
                 btnApply.Enabled = false;
                 btnOK.Enabled = false;


### PR DESCRIPTION
IsNullOrWhiteSpace() method already checks for empty string, so IsNullOrEmpty() can be safely removed.