### PR TITLE
Add a .NET Core 3.0 project

### DIFF
--- a/86BoxManager.sln
+++ b/86BoxManager.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.28010.2036
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "86BoxManager", "86boxManager\86BoxManager.csproj", "{559F81B9-D1A5-45FC-AA69-E98F3B3926BB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "86BoxManagerCore", "86BoxManagerCore\86BoxManagerCore.csproj", "{508DDE75-0405-47E9-9876-D3DF2D7047B3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,14 @@ Global
 		{559F81B9-D1A5-45FC-AA69-E98F3B3926BB}.Release|Any CPU.Build.0 = Release|x86
 		{559F81B9-D1A5-45FC-AA69-E98F3B3926BB}.Release|x86.ActiveCfg = Release|x86
 		{559F81B9-D1A5-45FC-AA69-E98F3B3926BB}.Release|x86.Build.0 = Release|x86
+		{508DDE75-0405-47E9-9876-D3DF2D7047B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{508DDE75-0405-47E9-9876-D3DF2D7047B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{508DDE75-0405-47E9-9876-D3DF2D7047B3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{508DDE75-0405-47E9-9876-D3DF2D7047B3}.Debug|x86.Build.0 = Debug|Any CPU
+		{508DDE75-0405-47E9-9876-D3DF2D7047B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{508DDE75-0405-47E9-9876-D3DF2D7047B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{508DDE75-0405-47E9-9876-D3DF2D7047B3}.Release|x86.ActiveCfg = Release|Any CPU
+		{508DDE75-0405-47E9-9876-D3DF2D7047B3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/86BoxManager/frmMain.cs
+++ b/86BoxManager/frmMain.cs
@@ -1,4 +1,6 @@
-﻿using IWshRuntimeLibrary;
+﻿#if NETFRAMEWORK
+using IWshRuntimeLibrary;
+#endif
 using Microsoft.Win32;
 using System;
 using System.ComponentModel;
@@ -49,6 +51,10 @@ namespace _86boxManager
             InitializeComponent();
             LoadSettings();
             LoadVMs();
+
+#if !NETFRAMEWORK
+            createADesktopShortcutToolStripMenuItem.Enabled = false;
+#endif
         }
 
         private void frmMain_Load(object sender, EventArgs e)
@@ -1130,6 +1136,7 @@ namespace _86boxManager
 
         private void createADesktopShortcutToolStripMenuItem_Click(object sender, EventArgs e)
         {
+#if NETFRAMEWORK
             VM vm = (VM)lstVMs.SelectedItems[0].Tag;
             WshShell shell = new WshShell();
             string shortcutAddress = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + @"\" + vm.Name + ".lnk";
@@ -1141,6 +1148,7 @@ namespace _86boxManager
             shortcut.Save();
 
             MessageBox.Show("A desktop shortcut for this virtual machine was successfully created.", "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
+#endif
         }
 
         //Starts/stops selected VM when enter is pressed

--- a/86BoxManagerCore/86BoxManagerCore.csproj
+++ b/86BoxManagerCore/86BoxManagerCore.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RootNamespace>_86BoxManager</RootNamespace>
+    <UseWindowsForms>true</UseWindowsForms>
+
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AssemblyName>86Manager</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\86BoxManager\**\*.cs" />
+    <EmbeddedResource Include="..\86BoxManager\**\*.resx" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Self-explanatory. Core does not support COM functionality required for shortcut creation, so I took the path of least resistance and put the shortcut code in `#if` blocks, which should compile only when the .NET Framework project is built.