### PR TITLE
Fix possible unintended order of execution on launch

### DIFF
--- a/86BoxManager/frmMain.cs
+++ b/86BoxManager/frmMain.cs
@@ -52,8 +52,6 @@ namespace _86boxManager
         public frmMain()
         {
             InitializeComponent();
-            LoadSettings();
-            LoadVMs();
 
 #if NETCOREAPP
             createADesktopShortcutToolStripMenuItem.Enabled = false; // Requires the original .NET framework
@@ -62,6 +60,9 @@ namespace _86boxManager
 
         private void frmMain_Load(object sender, EventArgs e)
         {
+            LoadSettings();
+            LoadVMs();
+
             //Load main window's state, size and position
             WindowState = Settings.Default.WindowState;
             Size = Settings.Default.WindowSize;


### PR DESCRIPTION
A video report of a bug from a user in 86Box discord suggests that frmMain_Load event can be fired before lstVMs is populated thus leading to exception: `"InvalidArgument=Value of '0' is not valid for 'startIndex'.\r\nParameter name: startIndex"` when started from a shortcut.

Moving LoadVMs (and LoadSettings for consistency) to frmMain_Load should make sure the list is ready. Also it is a common pattern to only initialize components in constructor and wait until loaded event is fired before using the components.